### PR TITLE
Add missing config option for `gsc` widget

### DIFF
--- a/content/reference/services/google-search-console/_index.md
+++ b/content/reference/services/google-search-console/_index.md
@@ -31,6 +31,7 @@ weight: 6
     services:
       google_search_console:
         keyfile: goanalytics-abc123.json
+        address: https://thevaluable.dev
 ```
 
 ## Widgets available


### PR DESCRIPTION
The reference page for the Google Search Console widget should mention the required configuration parameter `address`.

I used your page as an example, as it is also used in the other references.